### PR TITLE
fix for remove2d PR

### DIFF
--- a/include/gfx/Image2D.hpp
+++ b/include/gfx/Image2D.hpp
@@ -29,9 +29,7 @@ namespace gfx {
 			size = std::move(other.size);
 			return *this;
 		}
-		~Image2D() {
-			texture->drop();
-		}
+		~Image2D() = default;
 
 		irr::core::stringw filename;
 		irr::video::ITexture *texture{};


### PR DESCRIPTION
The destructor in Image2D was droping the texture and thus invalidating the pointer stored by the texture cache